### PR TITLE
Ensure output directories are created automatically

### DIFF
--- a/PSToolkit.ps1
+++ b/PSToolkit.ps1
@@ -16,6 +16,15 @@ $logPath = "$PSScriptRoot\Outputs\Logs\SupportLog_$timestamp.txt"
 # Define directory for JSON outputs to store structured results.
 $jsonPath = "$PSScriptRoot\Outputs\Json"
 
+# Ensure output directories exist before any data is written.
+$logDirectory = Split-Path -Path $logPath -Parent
+$jsonDirectory = $jsonPath
+foreach ($directory in @($logDirectory, $jsonDirectory)) {
+    if (-not (Test-Path -Path $directory)) {
+        New-Item -Path $directory -ItemType Directory -Force | Out-Null
+    }
+}
+
 <# 
     Log-Action
     Records timestamped actions to a session log to provide a traceable history of operations.

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ A PowerShell support toolkit designed to perform remote desktop support tasks ef
 
 1. Open **PowerShell as Administrator**.
 2. If needed, temporarily bypass the execution policy: Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-3. Run the script: ./PowerShellSupportToolkit.ps1
+3. Run the script: ./PSToolkit.ps1
 4. Follow the on-screen menu to select and run support tasks.
 
 ## Logs
 
-Every action is automatically logged in a timestamped .txt file. The log file is saved in the same directory as the script.
+Every action is automatically logged in a timestamped .txt file. The script automatically creates an `Outputs` folder alongside the script on first run. Log files are stored in `Outputs/Logs` and JSON data exports are written to `Outputs/Json`.
 
 ## License
 


### PR DESCRIPTION
## Summary
- create the Outputs/Logs and Outputs/Json folders on script start
- document the generated output locations and correct the script name in the README

## Testing
- not run (PowerShell script)


------
https://chatgpt.com/codex/tasks/task_e_68de28dbb5408332aa7beed845219d54